### PR TITLE
ENH: Parallelize find_d

### DIFF
--- a/fracdiff/fracdiffstat.py
+++ b/fracdiff/fracdiffstat.py
@@ -7,6 +7,8 @@ from sklearn.utils.validation import check_is_fitted
 from fracdiff import Fracdiff
 from fracdiff.stat import StatTester
 
+from concurrent.futures import ProcessPoolExecutor
+
 
 class FracdiffStat(TransformerMixin, BaseEstimator):
     """
@@ -50,6 +52,8 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         Upper limit of the range to search the order.
     lower : float, default 0.0
         Lower limit of the range to search the order.
+    n_jobs : int, deafult None
+        The number of jobs to run `fit` in parallel. -1 means using all processors
 
     Attributes
     ----------
@@ -84,6 +88,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         precision=0.01,
         upper=1.0,
         lower=0.0,
+        n_jobs=None
     ):
         self.window = window
         self.mode = mode
@@ -114,7 +119,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         """
         check_array(X)
 
-        self.d_ = numpy.array([self._find_d(X[:, i]) for i in range(X.shape[1])])
+        self.d_ = self._find_features_d(X)
 
         return self
 
@@ -150,6 +155,23 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
 
     def _is_stat(self, x) -> bool:
         return StatTester(method=self.stattest).is_stat(x, pvalue=self.pvalue)
+    
+    def _find_features_d(self, X) -> numpy.array:
+        num_features = X.shape[1]
+        if self.n_jobs is not None and self.n_jobs != 1:
+            max_workers = self.n_jobs
+
+            # use all cpus
+            if self.n_jobs == -1:
+                max_workers = None
+                
+            with ProcessPoolExecutor(max_workers=max_workers) as exec:
+                features = [X[:, i] for i in range(num_features)]
+                d_ = list(exec.map(self._find_d, features))
+        else:
+            d_ = [self._find_d(X[:, i]) for i in range(num_features)]
+
+        return numpy.array(d_)
 
     def _find_d(self, x) -> float:
         """

--- a/fracdiff/fracdiffstat.py
+++ b/fracdiff/fracdiffstat.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ProcessPoolExecutor
+
 import numpy
 from sklearn.base import BaseEstimator
 from sklearn.base import TransformerMixin
@@ -6,8 +8,6 @@ from sklearn.utils.validation import check_is_fitted
 
 from fracdiff import Fracdiff
 from fracdiff.stat import StatTester
-
-from concurrent.futures import ProcessPoolExecutor
 
 
 class FracdiffStat(TransformerMixin, BaseEstimator):
@@ -88,7 +88,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         precision=0.01,
         upper=1.0,
         lower=0.0,
-        n_jobs=None
+        n_jobs=None,
     ):
         self.window = window
         self.mode = mode
@@ -156,7 +156,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
 
     def _is_stat(self, x) -> bool:
         return StatTester(method=self.stattest).is_stat(x, pvalue=self.pvalue)
-    
+
     def _find_features_d(self, X) -> numpy.array:
         n_features = X.shape[1]
         if self.n_jobs is not None and self.n_jobs != 1:
@@ -165,7 +165,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
             # use all cpus
             if self.n_jobs == -1:
                 max_workers = None
-                
+
             with ProcessPoolExecutor(max_workers=max_workers) as exec:
                 features = [X[:, i] for i in range(n_features)]
                 d_ = list(exec.map(self._find_d, features))

--- a/fracdiff/fracdiffstat.py
+++ b/fracdiff/fracdiffstat.py
@@ -52,7 +52,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         Upper limit of the range to search the order.
     lower : float, default 0.0
         Lower limit of the range to search the order.
-    n_jobs : int, deafult None
+    n_jobs : int, default None
         The number of jobs to run `fit` in parallel. -1 means using all processors
 
     Attributes
@@ -98,6 +98,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         self.precision = precision
         self.upper = upper
         self.lower = lower
+        self.n_jobs = n_jobs
 
     def fit(self, X, y=None):
         """
@@ -157,7 +158,7 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
         return StatTester(method=self.stattest).is_stat(x, pvalue=self.pvalue)
     
     def _find_features_d(self, X) -> numpy.array:
-        num_features = X.shape[1]
+        n_features = X.shape[1]
         if self.n_jobs is not None and self.n_jobs != 1:
             max_workers = self.n_jobs
 
@@ -166,10 +167,10 @@ class FracdiffStat(TransformerMixin, BaseEstimator):
                 max_workers = None
                 
             with ProcessPoolExecutor(max_workers=max_workers) as exec:
-                features = [X[:, i] for i in range(num_features)]
+                features = [X[:, i] for i in range(n_features)]
                 d_ = list(exec.map(self._find_d, features))
         else:
-            d_ = [self._find_d(X[:, i]) for i in range(num_features)]
+            d_ = [self._find_d(X[:, i]) for i in range(n_features)]
 
         return numpy.array(d_)
 

--- a/tests/test_fracdiffstat.py
+++ b/tests/test_fracdiffstat.py
@@ -76,7 +76,9 @@ class TestFracdiffStat:
         np.random.seed(42)
         X = np.random.randn(100, 10).cumsum(0)
 
-        fs = FracdiffStat(window=window, mode=mode, precision=precision, n_jobs=n_jobs).fit(X)
+        fs = FracdiffStat(
+            window=window, mode=mode, precision=precision, n_jobs=n_jobs
+        ).fit(X)
         out = fs.transform(X)
 
         exp = np.empty_like(out[:, :0])

--- a/tests/test_fracdiffstat.py
+++ b/tests/test_fracdiffstat.py
@@ -19,11 +19,12 @@ class TestFracdiffStat:
     @pytest.mark.parametrize("window", [10])
     @pytest.mark.parametrize("mode", ["full", "valid"])
     @pytest.mark.parametrize("precision", [0.01])
-    def test_order(self, window, mode, precision):
+    @pytest.mark.parametrize("n_jobs", [None, -1])
+    def test_order(self, window, mode, precision, n_jobs):
         np.random.seed(42)
         X = np.random.randn(1000, 10).cumsum(0)
 
-        fs = FracdiffStat(mode=mode, window=window, precision=precision)
+        fs = FracdiffStat(mode=mode, window=window, precision=precision, n_jobs=n_jobs)
         fs.fit(X)
 
         X_st = fs.transform(X)
@@ -66,7 +67,8 @@ class TestFracdiffStat:
     @pytest.mark.parametrize("window", [10])
     @pytest.mark.parametrize("mode", ["full", "valid"])
     @pytest.mark.parametrize("precision", [0.01])
-    def test_transform(self, window, mode, precision):
+    @pytest.mark.parametrize("n_jobs", [None, -1])
+    def test_transform(self, window, mode, precision, n_jobs):
         """
         Test if `FracdiffStat.transform` works
         for array with n_features > 1.
@@ -74,7 +76,7 @@ class TestFracdiffStat:
         np.random.seed(42)
         X = np.random.randn(100, 10).cumsum(0)
 
-        fs = FracdiffStat(window=window, mode=mode, precision=precision).fit(X)
+        fs = FracdiffStat(window=window, mode=mode, precision=precision, n_jobs=n_jobs).fit(X)
         out = fs.transform(X)
 
         exp = np.empty_like(out[:, :0])


### PR DESCRIPTION
Each feature/series of the dataset is independent so parallelizing finding the minimum order of fractional differentiation for each one can speed up the process significantly