### PR TITLE
Add get_feature_names() function to FracdiffStat & Fracdiff sklearn pipeline transformations

### DIFF
--- a/fracdiff/sklearn/fracdiff.py
+++ b/fracdiff/sklearn/fracdiff.py
@@ -2,7 +2,9 @@ from typing import TypeVar
 
 import numpy
 import pandas as pd
+from sklearn.base import BaseEstimator  # type: ignore
 from sklearn.base import TransformerMixin  # type: ignore
+from sklearn.base import _OneToOneFeatureMixin  # type: ignore
 from sklearn.utils.validation import check_array  # type: ignore
 from sklearn.utils.validation import check_is_fitted  # type: ignore
 
@@ -12,7 +14,7 @@ from fracdiff.fdiff import fdiff_coef
 T = TypeVar("T", bound="Fracdiff")
 
 
-class Fracdiff(TransformerMixin):
+class Fracdiff(_OneToOneFeatureMixin, TransformerMixin):
     """A scikit-learn transformer to compute fractional differentiation.
 
     Parameters
@@ -113,9 +115,7 @@ class Fracdiff(TransformerMixin):
             Returns the instance itself.
         """
         if isinstance(X, pd.DataFrame):
-            self.column_names = list(X.columns)
-        else:
-            self.column_names = None
+            self.feature_names_in_ = X.columns.tolist()
         self.coef_ = fdiff_coef(self.d, self.window)
         return self
 
@@ -139,9 +139,3 @@ class Fracdiff(TransformerMixin):
         check_is_fitted(self, ["coef_"])
         check_array(X, estimator=self)
         return fdiff(X, n=self.d, axis=0, window=self.window, mode=self.mode)
-
-    def get_feature_names_out(self, feature_names_in=None):
-        if self.column_names is None:
-            raise RuntimeWarning("No column feature names. X is not a pd.DataFrame")
-        else:
-            return self.column_names

--- a/fracdiff/sklearn/fracdiff.py
+++ b/fracdiff/sklearn/fracdiff.py
@@ -1,6 +1,7 @@
 from typing import TypeVar
 
 import numpy
+import pandas as pd
 from sklearn.base import TransformerMixin  # type: ignore
 from sklearn.utils.validation import check_array  # type: ignore
 from sklearn.utils.validation import check_is_fitted  # type: ignore
@@ -111,6 +112,10 @@ class Fracdiff(TransformerMixin):
         self : object
             Returns the instance itself.
         """
+        if isinstance(X, pd.DataFrame):
+            self.column_names = list(X.columns)
+        else:
+            self.column_names = None
         self.coef_ = fdiff_coef(self.d, self.window)
         return self
 
@@ -134,3 +139,9 @@ class Fracdiff(TransformerMixin):
         check_is_fitted(self, ["coef_"])
         check_array(X, estimator=self)
         return fdiff(X, n=self.d, axis=0, window=self.window, mode=self.mode)
+
+    def get_feature_names_out(self, feature_names_in=None):
+        if self.column_names is None:
+            raise RuntimeWarning("No column feature names. X is not a pd.DataFrame")
+        else:
+            return self.column_names


### PR DESCRIPTION
Addressing issue: #125

Summary of work
- Added get_feature_names() method to FracdiffStat & Fracdiff
- When fit() is called, check and store column names in self.column_names
- When get_feature_names() is called, return self.column_names if available
- Raise error if X used for fit() was a numpy array

I've tested the above and include test cases below.
```
import numpy as np
import pandas as pd
from fracdiff.sklearn import FracdiffStat, Fracdiff
from sklearn import compose, pipeline, preprocessing
from sklearn.impute import SimpleImputer
from sklearn.ensemble import RandomForestClassifier

# Generate sample data
df = pd.DataFrame()
N = 1000
df['N1'] = np.random.random(size=N)
df['N2'] = np.random.random(size=N)
df['N3'] = np.random.random(size=N)
df['C1'] = np.random.choice(['a', 'b', 'c', 'd'], size=N, replace=True, p=None)
df['C2'] = np.random.choice(['a', 'b', 'c', 'd'], size=N, replace=True, p=None)
df['C3'] = np.random.choice(['a', 'b', 'c', 'd'], size=N, replace=True, p=None)
df['y_true'] = np.random.randint(0, 2, size=N)

# Test directly on Fracdiff
f1 = Fracdiff(0.5, window=3)
f1.fit(df[['N1', 'N2', 'N3']])
f1.get_feature_names_out()

# Test directly on FracdiffStat
f1 = FracdiffStat()
f1.fit(df[['N1', 'N2', 'N3']])
f1.get_feature_names_out()

# Test within sklearn pipeline using FracdiffStat
column_transformer = compose.make_column_transformer(
    (preprocessing.OneHotEncoder(handle_unknown='ignore', sparse=False), ['C1', 'C2', 'C3']),
    (FracdiffStat(), ['N1', 'N2', 'N3']))

simple_imputer = SimpleImputer(strategy='constant', fill_value=999)

model = RandomForestClassifier()

clf = pipeline.Pipeline(
    steps=[("column_transformer", column_transformer),
           ("simple_imputer", simple_imputer),
           ("classifier", model)])

clf.fit(X=df[['C1', 'C2', 'C3', 'N1', 'N2', 'N3']], y=df['y_true'])

feature_names_out = column_transformer.get_feature_names_out()

pd.DataFrame(column_transformer.transform(df[['C1', 'C2', 'C3', 'N1', 'N2', 'N3']]),
             columns=feature_names_out)
```

Caveat: I'm not an experienced coder. Please LMK if improvements / changes to be made. 